### PR TITLE
topcat containers now pull latest public release

### DIFF
--- a/desktop/topcat-terminal/Dockerfile
+++ b/desktop/topcat-terminal/Dockerfile
@@ -16,22 +16,12 @@ RUN touch /etc/sudo.conf && echo "Set disable_coredump false" > /etc/sudo.conf
 # JVM settings
 ENV JAVA_OPTS="-Xms512m -Xmx2048m -XX:+UseParallelGC -XX:+HeapDumpOnOutOfMemoryError -XX:OnError='cat hs_err_pid%p.log'"
 
-# install topcat with parquet and create stilts/topcat scripts
-ADD https://www.star.bris.ac.uk/~mbt/topcat/topcat-extra.jar /usr/local/bin/topcat-extra.jar
-RUN unzip -o /usr/local/bin/topcat-extra.jar -d /usr/local/bin topcat stilts \
-    && sed -i -e 's/topcat-full/topcat-extra/g' /usr/local/bin/topcat /usr/local/bin/stilts \
-    && chmod 644 /usr/local/bin/topcat-extra.jar \
-    && chmod 755 /usr/local/bin/stilts /usr/local/bin/topcat
-
-# Acquire a numbered TOPCAT release.
-# This URL is fairly stable, though not guaranteed in the long term.
-#ADD http://andromeda.star.bristol.ac.uk/releases/topcat/v4.8/topcat-full.jar /usr/bin/topcat-full.jar
-# Above URL was not working. The following URL was providing topcat version 4.8.8
-# Need to find a version specific URL.
-ADD https://www.star.bris.ac.uk/~mbt/topcat/topcat-full.jar /usr/bin/topcat-full.jar
-RUN unzip /usr/bin/topcat-full.jar -d /usr/bin topcat stilts
-RUN chmod 644 /usr/bin/topcat-full.jar
-RUN chmod 755 /usr/bin/topcat /usr/bin/stilts
+# install latest topcat release with parquet and create stilts/topcat scripts
+ADD http://www.starlink.ac.uk/topcat/topcat-extra.jar /usr/bin/topcat-extra.jar
+RUN unzip -o /usr/bin/topcat-extra.jar -d /usr/bin topcat stilts \
+    && sed -i -e 's/topcat-full/topcat-extra/g' /usr/bin/topcat /usr/bin/stilts \
+    && chmod 644 /usr/bin/topcat-extra.jar \
+    && chmod 755 /usr/bin/stilts /usr/bin/topcat
 
 # Prepare a startup message.
 RUN mkdir -p /usr/share/topcat

--- a/desktop/topcat-terminal/VERSION
+++ b/desktop/topcat-terminal/VERSION
@@ -1,4 +1,0 @@
-## deployable containers have a semantic and build tag
-# semantic version tag: major.minor
-# build version tag: timestamp
-TAGS="4.8.8 $(date -u +"%Y%m%dT%H%M%S")"

--- a/desktop/topcat-terminal/apply-version.sh
+++ b/desktop/topcat-terminal/apply-version.sh
@@ -1,7 +1,18 @@
 #!/bin/bash
-. VERSION && echo "tags: $TAGS"
+
+topcatimage=images.canfar.net/skaha/topcat-terminal
+
+# Extract topcat version from image.
+VERSION=`docker run ${topcatimage}:latest topcat -version | grep -i TOPCAT.version | sed 's/.*ersion //'`
+
+# Prepare tags: topcat version and build version (timestamp).
+TAGS="$VERSION $(date -u +'%Y%m%dT%H%M%S')"
+echo "tags: $TAGS"
+
+# Tag image.
 for t in $TAGS; do
-   docker image tag images.canfar.net/skaha/topcat-terminal:latest images.canfar.net/skaha/topcat-terminal:$t
+   docker image tag ${topcatimage}:latest ${topcatimage}:$t
 done
 unset TAGS
-docker image list images.canfar.net/skaha/topcat-terminal
+unset VERSION
+docker image list ${topcatimage}

--- a/desktop/topcat/Dockerfile
+++ b/desktop/topcat/Dockerfile
@@ -16,22 +16,12 @@ RUN touch /etc/sudo.conf && echo "Set disable_coredump false" > /etc/sudo.conf
 # JVM settings
 ENV JAVA_OPTS="-Xms512m -Xmx2048m -XX:+UseParallelGC -XX:+HeapDumpOnOutOfMemoryError -XX:OnError='cat hs_err_pid%p.log'"
 
-# install topcat with parquet and create stilts/topcat scripts
-ADD https://www.star.bris.ac.uk/~mbt/topcat/topcat-extra.jar /usr/local/bin/topcat-extra.jar
-RUN unzip -o /usr/local/bin/topcat-extra.jar -d /usr/local/bin topcat stilts \
-    && sed -i -e 's/topcat-full/topcat-extra/g' /usr/local/bin/topcat /usr/local/bin/stilts \
-    && chmod 644 /usr/local/bin/topcat-extra.jar \
-    && chmod 755 /usr/local/bin/stilts /usr/local/bin/topcat
-
-# Acquire a numbered TOPCAT release.
-# This URL is fairly stable, though not guaranteed in the long term.
-#ADD http://andromeda.star.bristol.ac.uk/releases/topcat/v4.8/topcat-full.jar /usr/bin/topcat-full.jar
-# Above URL was not working. The following URL was providing topcat version 4.8.8
-# Need to find a version specific URL.
-ADD https://www.star.bris.ac.uk/~mbt/topcat/topcat-full.jar /usr/bin/topcat-full.jar
-RUN unzip /usr/bin/topcat-full.jar -d /usr/bin topcat stilts
-RUN chmod 644 /usr/bin/topcat-full.jar
-RUN chmod 755 /usr/bin/topcat /usr/bin/stilts
+# install latest topcat release with parquet and create stilts/topcat scripts
+ADD http://www.starlink.ac.uk/topcat/topcat-extra.jar /usr/bin/topcat-extra.jar
+RUN unzip -o /usr/bin/topcat-extra.jar -d /usr/bin topcat stilts \
+    && sed -i -e 's/topcat-full/topcat-extra/g' /usr/bin/topcat /usr/bin/stilts \
+    && chmod 644 /usr/bin/topcat-extra.jar \
+    && chmod 755 /usr/bin/stilts /usr/bin/topcat
 
 # Prepare a startup message.
 RUN mkdir -p /usr/share/topcat

--- a/desktop/topcat/VERSION
+++ b/desktop/topcat/VERSION
@@ -1,4 +1,0 @@
-## deployable containers have a semantic and build tag
-# semantic version tag: major.minor
-# build version tag: timestamp
-TAGS="4.8.8 $(date -u +"%Y%m%dT%H%M%S")"

--- a/desktop/topcat/apply-version.sh
+++ b/desktop/topcat/apply-version.sh
@@ -1,7 +1,18 @@
 #!/bin/bash
-. VERSION && echo "tags: $TAGS"
+
+topcatimage=images.canfar.net/skaha/topcat
+
+# Extract topcat version from image.
+VERSION=`docker run ${topcatimage}:latest topcat -version | grep -i TOPCAT.version | sed 's/.*ersion //'`
+
+# Prepare tags: topcat version and build version (timestamp).
+TAGS="$VERSION $(date -u +'%Y%m%dT%H%M%S')"
+echo "tags: $TAGS"
+
+# Tag image.
 for t in $TAGS; do
-   docker image tag images.canfar.net/skaha/topcat:latest images.canfar.net/skaha/topcat:$t
+   docker image tag ${topcatimage}:latest ${topcatimage}:$t
 done
 unset TAGS
-docker image list images.canfar.net/skaha/topcat
+unset VERSION
+docker image list ${topcatimage}


### PR DESCRIPTION
Some changes made to the Dockerfile and apply-version.sh script for topcat and topcat-terminal packages.

- The Dockerfile now downloads only topcat-extra to /usr/bin; its previous behaviour was to pull topcat-extra to /usr/local and topcat-full to /usr/bin.  topcat-extra does everything that topcat-full does (plus parquet) so there is no point having both.

- The Dockerfile downloads the most recent public release, rather than thinking it's got a specific numbered release.

- The apply-version.sh script now extracts the correct version from the image rather than using a hard-coded version number in the VERSION file.  The VERSION files, which were used in apply-version.sh, have been deleted since it's easier to do it all in the apply-version.sh script.